### PR TITLE
Update AzSPoC to fix a failure in 2102 during the RegisterNewRPs step

### DIFF
--- a/deployment/AzSPoC.ps1
+++ b/deployment/AzSPoC.ps1
@@ -3214,7 +3214,7 @@ C:\AzSPoC\AzSPoC.ps1, you should find the Scripts folder located at C:\AzSPoC\Sc
     if (($progressCheck -eq "Incomplete") -or ($progressCheck -eq "Failed")) {
         try {
             # Register resource providers
-            foreach ($s in (Get-AzSubscription)) {
+            foreach ($s in (Get-AzSubscription | ?{$_.State -eq "Enabled"})) {
                 Set-AzContext -Subscription $s.SubscriptionId | Out-Null
                 Write-Progress $($s.SubscriptionId + " : " + $s.SubscriptionName)
                 Get-AzResourceProvider -ListAvailable | Register-AzResourceProvider


### PR DESCRIPTION
Starting in 2102 the Metering and Consumption subscriptions are disabled, and if you try to register RPs in a disabled subscription you will fail with the following error: "The subscription '...' is disabled and therefore marked as read only. You cannot perform any write actions on this subscription until it is re-enabled."  By adding a where to filter out any disabled subscriptions we avoid this error.